### PR TITLE
Cymerrad/etheratom

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ resolver
 ```typescript
 import { parsers, resolvers, ResolverEngine } from "@resolver-engine/core";
 
-const resolver = new ResolverEngine<string>()
-  .addResolver(resolvers.UriResolver())
-  .addParser(parsers.UrlParser());
+const resolver = new ResolverEngine<string>().addResolver(resolvers.UriResolver()).addParser(parsers.UrlParser());
 
 resolver.resolve("https://pastebin.com/raw/D8ziKX0a").then(console.log);
 ```
@@ -52,12 +50,12 @@ In the [`examples/` folder](examples/) more granular examples can be found.
 
 ### Published packages
 
-| Package                                               | NPM                                                                                                                            | Description                                                                  |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| Package                                               | NPM                                                                                                                             | Description                                                                  |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | [`@resolver-engine/imports-fs`](/packages/imports-fs) | [![npm link](https://img.shields.io/badge/npm-imports--fs-blue.svg)](https://www.npmjs.com/package/@resolver-engine/imports-fs) | Solidity imports with filesystem support                                     |
-| [`@resolver-engine/imports`](/packages/imports)       | [![npm link](https://img.shields.io/badge/npm-imports-blue.svg)](https://www.npmjs.com/package/@resolver-engine/imports)       | Browser-friendly version of Solidity imports                                 |
-| [`@resolver-engine/core`](packages/core)              | [![npm link](https://img.shields.io/badge/npm-core-blue.svg)](https://www.npmjs.com/package/@resolver-engine/core)             | Core of the project consisting of the engine and interfaces                  |
-| [`@resolver-engine/fs`](packages/fs)                  | [![npm link](https://img.shields.io/badge/npm-fs-blue.svg)](https://www.npmjs.com/package/@resolver-engine/fs)                 | Filesystem abstractions, basis for future artifacts resolver and many others |
+| [`@resolver-engine/imports`](/packages/imports)       | [![npm link](https://img.shields.io/badge/npm-imports-blue.svg)](https://www.npmjs.com/package/@resolver-engine/imports)        | Browser-friendly version of Solidity imports                                 |
+| [`@resolver-engine/core`](packages/core)              | [![npm link](https://img.shields.io/badge/npm-core-blue.svg)](https://www.npmjs.com/package/@resolver-engine/core)              | Core of the project consisting of the engine and interfaces                  |
+| [`@resolver-engine/fs`](packages/fs)                  | [![npm link](https://img.shields.io/badge/npm-fs-blue.svg)](https://www.npmjs.com/package/@resolver-engine/fs)                  | Filesystem abstractions, basis for future artifacts resolver and many others |
 
 ## Long description
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ resolver
 ```typescript
 import { parsers, resolvers, ResolverEngine } from "@resolver-engine/core";
 
-const resolver = new ResolverEngine<string>().addResolver(resolvers.UriResolver()).addParser(parsers.UrlParser());
+const resolver = new ResolverEngine<string>()
+  .addResolver(resolvers.UriResolver())
+  .addParser(parsers.UrlParser());
 
 resolver.resolve("https://pastebin.com/raw/D8ziKX0a").then(console.log);
 ```

--- a/examples/github.ts
+++ b/examples/github.ts
@@ -1,6 +1,8 @@
 import { ResolverEngine } from "@resolver-engine/core";
 import { resolvers, parsers } from "@resolver-engine/imports";
 
-const resolver = new ResolverEngine<string>({ debug: true }).addParser(parsers.UrlParser()).addResolver(resolvers.GithubResolver());
+const resolver = new ResolverEngine<string>({ debug: true })
+  .addParser(parsers.UrlParser())
+  .addResolver(resolvers.GithubResolver());
 
 resolver.require("github:crypto-punkers/resolver-engine/examples/github.ts").then(console.log);

--- a/examples/github.ts
+++ b/examples/github.ts
@@ -1,5 +1,5 @@
 import { ResolverEngine } from "@resolver-engine/core";
-import { resolvers, parsers } from "@resolver-engine/imports";
+import { parsers, resolvers } from "@resolver-engine/imports";
 
 const resolver = new ResolverEngine<string>({ debug: true })
   .addParser(parsers.UrlParser())

--- a/examples/github.ts
+++ b/examples/github.ts
@@ -1,5 +1,4 @@
-import { ResolverEngine } from "@resolver-engine/core";
-import { parsers, resolvers } from "@resolver-engine/imports";
+import { parsers, ResolverEngine, resolvers } from "@resolver-engine/imports";
 
 const resolver = new ResolverEngine<string>({ debug: true })
   .addParser(parsers.UrlParser())

--- a/examples/identity.ts
+++ b/examples/identity.ts
@@ -1,6 +1,8 @@
 import { resolvers, parsers } from "@resolver-engine/fs";
 import { ResolverEngine } from "@resolver-engine/core";
 
-const resolver = new ResolverEngine<string>({ debug: true }).addResolver(resolvers.FsResolver()).addParser(parsers.FsParser());
+const resolver = new ResolverEngine<string>({ debug: true })
+  .addResolver(resolvers.FsResolver())
+  .addParser(parsers.FsParser());
 
 resolver.require(__filename).then(identity => console.log(identity.substr(0, 128)));

--- a/examples/identity.ts
+++ b/examples/identity.ts
@@ -1,5 +1,4 @@
-import { resolvers, parsers } from "@resolver-engine/fs";
-import { ResolverEngine } from "@resolver-engine/core";
+import { parsers, ResolverEngine, resolvers } from "@resolver-engine/fs";
 
 const resolver = new ResolverEngine<string>({ debug: true })
   .addResolver(resolvers.FsResolver())

--- a/examples/multiple.ts
+++ b/examples/multiple.ts
@@ -1,5 +1,4 @@
-import { ResolverEngine } from "@resolver-engine/core";
-import { parsers, resolvers } from "@resolver-engine/imports-fs";
+import { parsers, ResolverEngine, resolvers } from "@resolver-engine/imports-fs";
 
 const resolver = new ResolverEngine<string>()
   .addResolver(resolvers.FsResolver())

--- a/examples/multiple.ts
+++ b/examples/multiple.ts
@@ -1,5 +1,5 @@
 import { ResolverEngine } from "@resolver-engine/core";
-import { resolvers, parsers} from "@resolver-engine/imports-fs";
+import { parsers, resolvers } from "@resolver-engine/imports-fs";
 
 const resolver = new ResolverEngine<string>()
   .addResolver(resolvers.FsResolver())

--- a/examples/network.ts
+++ b/examples/network.ts
@@ -1,7 +1,7 @@
 import { ResolverEngine, resolvers, parsers } from "@resolver-engine/core";
 
-const resolver = new ResolverEngine<string>({ debug: true }).addParser(parsers.UrlParser()).addResolver(resolvers.UriResolver());
+const resolver = new ResolverEngine<string>({ debug: true })
+  .addParser(parsers.UrlParser())
+  .addResolver(resolvers.UriResolver());
 
-resolver
-  .require("https://www.apple.com/library/test/success.html")
-  .then(console.log);
+resolver.require("https://www.apple.com/library/test/success.html").then(console.log);

--- a/examples/node.ts
+++ b/examples/node.ts
@@ -1,5 +1,4 @@
-import { ResolverEngine } from "@resolver-engine/core";
-import { resolvers } from "@resolver-engine/fs";
+import { ResolverEngine, resolvers } from "@resolver-engine/fs";
 
 const resolver = new ResolverEngine<string>({ debug: true }).addResolver(resolvers.NodeResolver());
 

--- a/examples/resolc.ts
+++ b/examples/resolc.ts
@@ -6,8 +6,7 @@ const solc = require("solc");
 const chalk = require("chalk");
 const yargs = require("yargs");
 
-import { gatherSources } from "@resolver-engine/imports";
-import { ImportsFsEngine } from "@resolver-engine/imports-fs";
+import { gatherSources, ImportsFsEngine } from "@resolver-engine/imports-fs";
 import glob = require("glob");
 
 var argv = yargs.argv;

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "npmClient": "yarn",
   "version": "0.3.2"
 }

--- a/packages/fs/src/index.ts
+++ b/packages/fs/src/index.ts
@@ -1,3 +1,4 @@
+export { Context, firstResult, Options, ResolverEngine, SubParser, SubResolver } from "@resolver-engine/core";
 import { parsers as coreParsers, resolvers as coreResolvers } from "@resolver-engine/core";
 import { FsParser } from "./parsers/fsparser";
 import { BacktrackFsResolver } from "./resolvers/backtrackfsresolver";
@@ -9,11 +10,9 @@ export const resolvers = {
   FsResolver,
   NodeResolver,
   UriResolver: coreResolvers.UriResolver,
-  // ...coreResolvers,
 };
 
 export const parsers = {
   FsParser,
   UrlParser: coreParsers.UrlParser,
-  // ...coreParsers,
 };

--- a/packages/imports-fs/src/index.ts
+++ b/packages/imports-fs/src/index.ts
@@ -1,3 +1,11 @@
+export { Context, firstResult, Options, ResolverEngine, SubParser, SubResolver } from "@resolver-engine/core";
+export {
+  findImports,
+  gatherSources,
+  gatherSourcesAndCanonizeImports,
+  ImportFile,
+  ImportsEngine,
+} from "@resolver-engine/imports";
 export { ImportsFsEngine } from "./importsfsengine";
 import { parsers as coreParsers, resolvers as coreResolvers } from "@resolver-engine/core";
 import { parsers as fsParsers, resolvers as fsResolvers } from "@resolver-engine/fs";

--- a/packages/imports/src/index.ts
+++ b/packages/imports/src/index.ts
@@ -1,6 +1,6 @@
 export { ImportsEngine } from "./importsengine";
 export { ImportFile } from "./parsers/importparser";
-export * from "./utils";
+export { findImports, gatherSources, gatherSourcesAndCanonizeImports } from "./utils";
 import { parsers as core_p, resolvers as core_r } from "@resolver-engine/core";
 import { ImportParser } from "./parsers/importparser";
 import { GithubResolver } from "./resolvers/githubresolver";


### PR DESCRIPTION
This is the change I wanted to make a while back.  
It simplifies usage of the packages, by exporting everything from imported package and its dependencies.  
Look at the examples for what I mean by that.  
  
Changes are bundled with etheratom PR, because there are some exporting nuances involved, that I had to solve. This will also make my etheratom and remix-ide PR's more pleasant to the eye.